### PR TITLE
Pad to 16k for all types of ROM output

### DIFF
--- a/src/Main.asm
+++ b/src/Main.asm
@@ -32,7 +32,9 @@ MAINBEGIN:
 	INCLUDE "MainTests.asm"
 	ENT
 ENDOFPROG:
-	IFDEF DandanatorSupport
+	IFDEF UpperROM
+		ds 65536-ENDOFPROG		;; Round it up to 16 KB
+	ELSE
 		ds 16384-ENDOFPROG		;; Round it up to 16 KB
 	ENDIF
 


### PR DESCRIPTION
This is in preparation for easier extraction and injection for a font editor. Also, it's neater to always have 16k ROMs no matter what their content is.