### PR TITLE
Vendor and Refresh

### DIFF
--- a/src/Main.asm
+++ b/src/Main.asm
@@ -133,6 +133,7 @@ RAMInitialize:
 
  INCLUDE "MainMenu.asm"
  INCLUDE "Model.asm"
+ INCLUDE "Vendor.asm"
  INCLUDE "SoakTest.asm"
  INCLUDE "CheckUpperRAM.asm"
  INCLUDE "UtilsPrint.asm"

--- a/src/MainMenu.asm
+++ b/src/MainMenu.asm
@@ -177,6 +177,9 @@ TestComplete:
 
 TxtSystemInfo:	db 'SYSTEM INFO  ',0
 TxtModel: 	db 'MODEL     : ',0
+TxtVendor: 	db 'VENDOR    : ',0
+TxtRefresh:	db 'REFRESH   : ',0
+;TxtPPIPB:	db 'PPI PORTB : ',0
 TxtRAM: 	db 'RAM       : ',0
 TxtCRTC: 	db 'CRTC      : ',0
 TxtKB: 		db 'KB',0
@@ -280,6 +283,53 @@ SetUpScreen:
 	ld	hl, ModelNames
 	add	hl, de
 	call	PrintString
+
+    ;; VENDOR
+	pop	hl
+	inc	l
+	push 	hl
+ 	ld	(TxtCoords), hl
+	ld 	hl, TxtVendor
+	call 	PrintString
+	ld	a, (VendorName)
+	ld	e, a
+	ld	d, 0
+	ld	hl, VendorTableOffset
+	add	hl, de                 ; offset
+	ld	a, (hl)
+	ld	e, a
+	ld	hl, VendorNames
+	add	hl, de                 ; 1st name + offset
+	call    PrintString
+
+    ;; REFRESH
+	pop	hl
+	inc	l
+	push 	hl
+ 	ld	(TxtCoords), hl
+	ld 	hl, TxtRefresh
+	call 	PrintString
+	ld	a, (RefreshFrequency)
+	ld	e, a
+	ld	d, 0
+	ld	hl, RefreshTableOffset
+	add	hl, de
+	ld	a, (hl)
+	ld	e, a
+	ld	hl, RefreshNames
+	add	hl, de
+	call    PrintString
+
+	;; PPI Port B
+	;pop	hl
+	;inc	l
+	;push 	hl
+ 	;ld	(TxtCoords), hl
+	;ld 	hl, TxtPPIPB
+	;call 	PrintString
+	;ld b,#f5			; PPI port B input
+ 	;in a,(c)            	
+	;call    PrintABin
 
 	;; RAM
 	pop	hl

--- a/src/MainMenu.asm
+++ b/src/MainMenu.asm
@@ -179,7 +179,6 @@ TxtSystemInfo:	db 'SYSTEM INFO  ',0
 TxtModel: 	db 'MODEL     : ',0
 TxtVendor: 	db 'VENDOR    : ',0
 TxtRefresh:	db 'REFRESH   : ',0
-;TxtPPIPB:	db 'PPI PORTB : ',0
 TxtRAM: 	db 'RAM       : ',0
 TxtCRTC: 	db 'CRTC      : ',0
 TxtKB: 		db 'KB',0
@@ -320,17 +319,6 @@ SetUpScreen:
 	add	hl, de
 	call    PrintString
 
-	;; PPI Port B
-	;pop	hl
-	;inc	l
-	;push 	hl
- 	;ld	(TxtCoords), hl
-	;ld 	hl, TxtPPIPB
-	;call 	PrintString
-	;ld b,#f5			; PPI port B input
- 	;in a,(c)            	
-	;call    PrintABin
-
 	;; RAM
 	pop	hl
 	inc	l
@@ -354,7 +342,7 @@ SetUpScreen:
 	ld 	hl, TxtKB
 	call 	PrintString
 
-	;; CRTC yype
+	;; CRTC type
 	pop	hl
 	inc	l
 	push 	hl

--- a/src/SystemInfo.asm
+++ b/src/SystemInfo.asm
@@ -4,6 +4,8 @@
 	;; Try to detect the model and language
 	call	CalculateTotalUpperRAM
 	call	DetectModel
+	call    DetectVendor
+	call    RefreshFrequency
 
 	;; From the model, determine the keyboard layout
 	ld	a, (ModelType)

--- a/src/UtilsPrint.asm
+++ b/src/UtilsPrint.asm
@@ -138,3 +138,30 @@ PrintHLDec:
 	add a,#30
 	call PrintChar
 	ret
+
+
+
+print0:
+        ld a, "0"
+        call PrintChar
+        jr shiftleft
+
+print1:
+        ld a, "1"
+        call PrintChar
+        jr shiftleft
+
+;IN A = number to print
+;Modifies BC
+PrintABin:
+       ld c, a       ;save a
+       ld b, 8
+loopPrintABin:     
+       bit 7, c
+       jr z, print0
+       jr nz, print1
+shiftleft:       
+       sla c
+       dec b
+       jr nz, loopPrintABin
+	   ret

--- a/src/Variables.asm
+++ b/src/Variables.asm
@@ -8,7 +8,8 @@ UpperROMConfig: db 0				; Here we store the upper ROM we were launched from
 ModelType: db 0
 KeyboardLanguage: db 0
 FDCPresent: db 0
-
+VendorName: db 0
+RefreshFrequency: db 0
 
 ;; Upper RAM test
 ValidBankCount: db 0

--- a/src/Vendor.asm
+++ b/src/Vendor.asm
@@ -28,15 +28,6 @@ TxtIsp: db "ISP",0
 	db TxtTriumph - TxtAmstrad
 	db TxtIsp - TxtAmstrad
 
-;@VENDOR_AMSTRAD      EQU 0
-;@VENDOR_ORION        EQU 1
-;@VENDOR_SCHNEIDER    EQU 2
-;@VENDOR_AWA          EQU 3
-;@VENDOR_SOLAVOX      EQU 4
-;@VENDOR_SAISHO       EQU 5
-;@VENDOR_TRIUMPH      EQU 6
-;@VENDOR_ISP          EQU 7
-
 @RefreshNames:
 Txt50HZ: db "50Hz",0
 Txt60HZ: db "60Hz",0

--- a/src/Vendor.asm
+++ b/src/Vendor.asm
@@ -8,27 +8,26 @@
 ;; www.cpcwiki.eu/index.php/8255#PPI_Port_B
 ;; LK4 default 50Hz screen refresh
 
-@VendorNames:
-TxtAmstrad: db "AMSTRAD",0
-TxtOrion: db "ORION",0
+; ALL in UPPERCASE, we do not have lowercase chars in this ROM!!!
+@VendorNames:                    
+TxtAmstrad:   db "AMSTRAD",0
+TxtOrion:     db "ORION",0
 TxtSchneider: db "SCHNEIDER",0
-TxtAwa: db "AWA",0
-TxtSolavox: db "SOLAVOX",0
-TxtSaisho: db "SAISHO",0
-TxtTriumph: db "TRIUMPH",0
-TxtIsp: db "ISP",0            
-
-;; Offsets from VendorNames
+TxtAwa:       db "AWA",0
+TxtSolavox:   db "SOLAVOX",0
+TxtSaisho:    db "SAISHO",0
+TxtTriumph:   db "TRIUMPH",0
+TxtIsp:       db "ISP",0            
 
 @VendorTableOffset:
 	db 0
-	db TxtOrion - TxtAmstrad
+	db TxtOrion     - TxtAmstrad
 	db TxtSchneider - TxtAmstrad
-	db TxtAwa - TxtAmstrad
-	db TxtSolavox - TxtAmstrad
-	db TxtSaisho - TxtAmstrad
-	db TxtTriumph - TxtAmstrad
-	db TxtIsp - TxtAmstrad
+	db TxtAwa       - TxtAmstrad
+	db TxtSolavox   - TxtAmstrad
+	db TxtSaisho    - TxtAmstrad
+	db TxtTriumph   - TxtAmstrad
+	db TxtIsp       - TxtAmstrad
 
 @RefreshNames:
 Txt50HZ: db "50Hz",0
@@ -39,21 +38,22 @@ Txt60HZ: db "60Hz",0
 	db Txt60HZ - Txt50HZ
 
 ;; OUT:	(Vendor) - vendor from LK3-1 configuration
+;; OUT: (Frequency) - ;; www.cpcwiki.eu/index.php/LK_Links
 @DetectVendor:
-	ld b,#f5			; PPI port B input
-    in a,(c)            ; lower byte bits7-0
+    ld b,#f5			; PPI port B.
+    in a,(c)            ; Addressing, B in top half, C in bottom half (ignored)
     cpl                 ; invert bits
     and %00001110	    ; Links LK3-LK1 define machine
     rrca                ; get rid of bit0
-	ld (VendorName),a
-	ret
+    ld (VendorName),a
+    ret
 
 ;;  OUT: (Frequency) - frequency from LK4 configuration
 @DetectFrequency:
-	ld b,#f5			; PPI port B input
- 	in a,(c)            ; 
-	and %00010000       ; LK4 50/60 Hz  &10/&00 
-	ld (RefreshFrequency),a
-	ret
+    ld b,#f5			; PPI port B input
+    in a,(c)            ; 
+    and %00010000       ; LK4 50/60 Hz  &10/&00 
+    ld (RefreshFrequency),a
+    ret
     
  ENDMODULE

--- a/src/Vendor.asm
+++ b/src/Vendor.asm
@@ -1,10 +1,12 @@
  MODULE VENDOR
 
-;; Useful info from here:
 ;; www.cpcwiki.eu/index.php/LK-selectable_Brand_Names
-;; LK1,LK2,LK3 are optional links on the CPC mainboard, connected to PPI Port B, Bit1-3. The links select the distributor name (which is displayed by the BIOS in the boot message). 
 ;; www.cpcwiki.eu/index.php/LK_Links
-;; LK4 default 50Hz
+;; LK1,LK2,LK3 are optional links on the CPC mainboard, connected to PPI Port B, Bit1-3. 
+;; The links select the distributor name (which is displayed by the BIOS in the boot message). 
+
+;; www.cpcwiki.eu/index.php/8255#PPI_Port_B
+;; LK4 default 50Hz screen refresh
 
 @VendorNames:
 TxtAmstrad: db "AMSTRAD",0

--- a/src/Vendor.asm
+++ b/src/Vendor.asm
@@ -1,0 +1,66 @@
+ MODULE VENDOR
+
+;; Useful info from here:
+;; www.cpcwiki.eu/index.php/LK-selectable_Brand_Names
+;; LK1,LK2,LK3 are optional links on the CPC mainboard, connected to PPI Port B, Bit1-3. The links select the distributor name (which is displayed by the BIOS in the boot message). 
+;; www.cpcwiki.eu/index.php/LK_Links
+;; LK4 default 50Hz
+
+@VendorNames:
+TxtAmstrad: db "AMSTRAD",0
+TxtOrion: db "ORION",0
+TxtSchneider: db "SCHNEIDER",0
+TxtAwa: db "AWA",0
+TxtSolavox: db "SOLAVOX",0
+TxtSaisho: db "SAISHO",0
+TxtTriumph: db "TRIUMPH",0
+TxtIsp: db "ISP",0            
+
+;; Offsets from VendorNames
+
+@VendorTableOffset:
+	db 0
+	db TxtOrion - TxtAmstrad
+	db TxtSchneider - TxtAmstrad
+	db TxtAwa - TxtAmstrad
+	db TxtSolavox - TxtAmstrad
+	db TxtSaisho - TxtAmstrad
+	db TxtTriumph - TxtAmstrad
+	db TxtIsp - TxtAmstrad
+
+;@VENDOR_AMSTRAD      EQU 0
+;@VENDOR_ORION        EQU 1
+;@VENDOR_SCHNEIDER    EQU 2
+;@VENDOR_AWA          EQU 3
+;@VENDOR_SOLAVOX      EQU 4
+;@VENDOR_SAISHO       EQU 5
+;@VENDOR_TRIUMPH      EQU 6
+;@VENDOR_ISP          EQU 7
+
+@RefreshNames:
+Txt50HZ: db "50Hz",0
+Txt60HZ: db "60Hz",0
+
+@RefreshTableOffset:
+	db 0
+	db Txt60HZ - Txt50HZ
+
+;; OUT:	(Vendor) - vendor from LK3-1 configuration
+@DetectVendor:
+	ld b,#f5			; PPI port B input
+    in a,(c)            ; lower byte bits7-0
+    cpl                 ; invert bits
+    and %00001110	    ; Links LK3-LK1 define machine
+    rrca                ; get rid of bit0
+	ld (VendorName),a
+	ret
+
+;;  OUT: (Frequency) - frequency from LK4 configuration
+@DetectFrequency:
+	ld b,#f5			; PPI port B input
+ 	in a,(c)            ; 
+	and %00010000       ; LK4 50/60 Hz  &10/&00 
+	ld (RefreshFrequency),a
+	ret
+    
+ ENDMODULE

--- a/src/Vendor.asm
+++ b/src/Vendor.asm
@@ -38,7 +38,6 @@ Txt60HZ: db "60Hz",0
 	db Txt60HZ - Txt50HZ
 
 ;; OUT:	(Vendor) - vendor from LK3-1 configuration
-;; OUT: (Frequency) - ;; www.cpcwiki.eu/index.php/LK_Links
 @DetectVendor:
     ld b,#f5			; PPI port B.
     in a,(c)            ; Addressing, B in top half, C in bottom half (ignored)


### PR DESCRIPTION
Hi, I have added vendor, screen and PPI PortB register

LK1-3 inform about Vendor name
LK4 inform about screen refresh rate

I have tested vendor names with caprice32 -O system.jumpers
30 amstrad
60 orion
90 schneider
120 awa
20 saisho
50 triumph
80 Isp

-O system.model=0 for 464 , 1 for 664 2 for 6128 4 for plus (default model 2)

#start diag on Orion
cap32 -O system.jumpers=60 -a "run\"diag" build/AmstradDiag.dsk

I could not test screen rate, maybe someone with real 60Hz can try it.

Enjoy it!